### PR TITLE
fix: 네이티브에서  토큰을 못가져온 경우를 대비해 한 번 더 요청하는 로직 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,10 +22,11 @@ function App() {
 
   const dispatch = useDispatch();
 
-  const { isLoading } = useQuery("myProfile", ApiInstance.getProfile, {
+  const { isLoading, refetch } = useQuery("myProfile", ApiInstance.getProfile, {
     onSuccess: ({ data }) => {
       if (!data.success) {
-        return navigate("/welcome");
+        refetch();
+        return navigate("/welcome", { replace: true });
       }
 
       const user = {

--- a/src/pages/WelcomePage.js
+++ b/src/pages/WelcomePage.js
@@ -11,7 +11,7 @@ function WelcomePage() {
 
   useEffect(() => {
     if (user.name) {
-      navigate("/");
+      navigate("/", { replace: true });
     }
   }, [navigate, user.name]);
 


### PR DESCRIPTION
## 설명

프로필 탭을 누르고 웹뷰가 로딩되는 순간 유저의 정보를 백엔드에 요청하는데, 네이티브에서 토큰을 비동기적으로 가져와서 요청하기 때문에 순서가 뒤바뀐 문제가 생긴 것이 아닐까 하는 마음에 재요청 하는 로직을 추가했습니다.

## 변경 또는 추가한 로직
